### PR TITLE
Add libcurl.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: e72243251bbbec341bc5864305bb8cc23d311d19c5d0d9310afec7eb35aa2bfb
 
 build:
-  number: 0
+  number: 1
   # skip windows due to compilation failures
   skip: true  # [win]
   rpaths:
@@ -30,11 +30,13 @@ requirements:
     - {{native}}toolchain  # [win]
     - gcc                  # [not win]
     - curl
+    - libcurl
 
   run:
     - r-base
     - r-bitops
     - curl
+    - libcurl
 
 test:
   commands:


### PR DESCRIPTION
This recipe doesn't run properly on Red Hat 4.4.7-4 without installing libcurl first, leading to problems with other libraries using it. For example:

```
Error: package or namespace load failed for ‘GenomeInfoDb’ in dyn.load(file, DLLpath = DLLpath, ...):
unable to load shared object '/gpfs/ngs/usr/safary/miniconda/envs/bcb_rna/lib/R/library/RCurl/libs/RCurl.so':
/gpfs/ngs/usr/safary/miniconda/envs/bcb_rna/lib/R/library/RCurl/libs/../../../../libcurl.so.4: undefined symbol: SSL_CTX_set_alpn_protos
Error: package ‘GenomeInfoDb’ could not be loaded
```